### PR TITLE
feat: 調整mock API欄位與後端一致

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -2,49 +2,48 @@
 import { rest } from "msw";
 import { faker } from "@faker-js/faker";
 
-
-
 const postData = [
   {
-    id: 1650284959971,
-    userPhoto: faker.internet.avatar(),
+    _id: Date.now(),
     userName: "邊緣小杰",
+    avatar: faker.internet.avatar(),
     content: "外面看起來就超冷.... \n我決定回被窩繼續睡....>.<",
-    coverImage: faker.image.nature(1200, 600)
+    updateImage: faker.image.nature(1200, 600),
+    likes: faker.random.number({ min: 1, max: 100 }),
+    comments: faker.random.number({ min: 1, max: 100 }),
+    replies: [],
   },
 ];
 
-
 export const setFakeData = () => {
-    !localStorage.getItem("posts") &&
+  !localStorage.getItem("posts") &&
     localStorage.setItem("posts", JSON.stringify(postData));
-}
+};
 
 export const handlers = [
-
   rest.get("/posts", (req, res, ctx) => {
     const posts = JSON.parse(localStorage.getItem("posts"));
     return res(
       ctx.status(200),
       ctx.json({
-        message: "success",
-        posts,
+        status: "success",
+        data: { data: posts },
       })
     );
   }),
 
   rest.post("/posts", async (req, res, ctx) => {
-    const { userName, userPhoto, content, coverImage } = req.body;
+    const { userName, avatar, content, updateImage } = req.body;
     if (
       userName === undefined ||
-      userPhoto === undefined ||
+      avatar === undefined ||
       content === undefined ||
-      coverImage === undefined
+      updateImage === undefined
     ) {
-
       return res(
         ctx.status(400),
         ctx.json({
+          status: "fail",
           message: "參數有缺",
         })
       );
@@ -52,19 +51,22 @@ export const handlers = [
 
     const posts = JSON.parse(localStorage.getItem("posts"));
     const newPost = {
-        id: Date.now(),
-        userPhoto: faker.internet.avatar(),
-        userName,
-        content,
-        coverImage: faker.image.nature(1200, 600)
-    }
-    posts.push(newPost)
+      _id: Date.now(),
+      userName,
+      avatar: faker.internet.avatar(),
+      content,
+      updateImage: faker.image.nature(1200, 600),
+      likes: faker.random.number({ min: 1, max: 100 }),
+      comments: faker.random.number({ min: 1, max: 100 }),
+      replies: [],
+    };
+    posts.push(newPost);
     localStorage.setItem("posts", JSON.stringify(posts));
 
     return res(
       ctx.status(200),
       ctx.json({
-        message: "success",
+        status: "success",
         post: newPost,
       })
     );


### PR DESCRIPTION
**/posts (GET取得貼文列表)**
更改為

```javascript
{
    status: "success",
    data: { 
        data: [
                  {
                      _id: Date.now(),
                      userName: "邊緣小杰",
                      avatar: faker.internet.avatar(),
                      content: "外面看起來就超冷.... \n我決定回被窩繼續睡....>.<",
                      updateImage: faker.image.nature(1200, 600),
                      likes: faker.random.number({ min: 1, max: 100 }),
                      comments: faker.random.number({ min: 1, max: 100 }),
                      replies: [],
                 },
          ] 
     }
}

```

---

**/posts (POST新增貼文)**
參數改傳 userName, avatar, content, updateImage